### PR TITLE
2.0.2 cook

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/CoarseCookSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/CoarseCookSchedulerBackend.scala
@@ -77,9 +77,8 @@ class CoarseCookSchedulerBackend(
   scheduler: TaskSchedulerImpl,
   sc: SparkContext,
   cookHost: String,
-  cookPort: Int)
-    extends CoarseGrainedSchedulerBackend(scheduler, sc.env.rpcEnv) with Logging
-    with MesosSchedulerUtils {
+  cookPort: Int
+) extends CoarseGrainedSchedulerBackend(scheduler, sc.env.rpcEnv) with Logging with MesosSchedulerUtils {
 
   val maxCores = conf.getInt("spark.cores.max", 0)
   val maxCoresPerJob = conf.getInt("spark.executor.cores", 1)
@@ -110,6 +109,7 @@ class CoarseCookSchedulerBackend(
     .setStatusUpdateInterval(10)
     .setBatchRequestSize(24)
     .setKerberosAuth()
+    .setRetries(1)
     .build()
 
   private[this] val jobListener = new CJobListener {

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -89,6 +89,12 @@ abstract class AbstractCommandBuilder {
    */
   List<String> buildJavaCommand(String extraClassPath) throws IOException {
     List<String> cmd = new ArrayList<>();
+    String javaCommand = System.getenv("JAVA_CMD");
+    if (javaCommand != null) {
+      cmd.addAll(Arrays.asList(javaCommand.trim().split("\\s+")));
+      return cmd;
+    }
+
     String envJavaHome;
 
     if (javaHome != null) {


### PR DESCRIPTION
Support using synthetic java executable instead of standard `$JAVA_HOME/bin/java`. 

This code path is only used in `local-cluster` mode and will be useful for running unit test under `local-cluster` mode via different java-like runner.