### PR TITLE
Export executor id as environment variable

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/CoarseCookSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/CoarseCookSchedulerBackend.scala
@@ -235,6 +235,7 @@ class CoarseCookSchedulerBackend(
         .map { v =>
           s"export ${v.getName}=" + "\"" + v.getValue + "\""
         } ++
+        Seq(s"export SPARK_EXECUTOR_ID=$executorId")
         Seq("export SPARK_LOCAL_DIRS=$MESOS_SANDBOX/spark-temp",
             "mkdir $SPARK_LOCAL_DIRS") ++
         Seq(s"export SPARK_EXECUTOR_APP_ID=${applicationId()}") ++


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
Export executor id as an env variable named SPARK_EXECUTOR_ID

## How was this patch tested?
Compile and run 

