### PR TITLE
Expose executor limit

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/CoarseCookSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/CoarseCookSchedulerBackend.scala
@@ -127,7 +127,7 @@ class CoarseCookSchedulerBackend(
     * when creating `SparkContext` via `ExecutorAllocationManager.start()`;
     * otherwise, it is set via the `start()` of this backend.
     */
-  private def executorLimit: Int = this.synchronized {
+  private[scheduler] def executorLimit: Int = this.synchronized {
     executorLimitOption.getOrElse(Int.MaxValue)
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/CookSchedulerContext.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/CookSchedulerContext.scala
@@ -25,6 +25,13 @@ case class CookSchedulerContext(
 
   @transient val conf: SparkConf = sc.getConf
 
+  @transient val schedulerBackend: CoarseCookSchedulerBackend = {
+    require(sc.schedulerBackend.isInstanceOf[CoarseCookSchedulerBackend],
+      "The current scheduler backend is not Cook.")
+    sc.schedulerBackend
+      .asInstanceOf[CoarseCookSchedulerBackend]
+  }
+
   // ==========================================================================
   // Configurations that will be used by Cook scheduler backend
 
@@ -105,14 +112,18 @@ case class CookSchedulerContext(
   /**
     * @return executor ids of alive executors.
     */
-  def getExecutorIds: Seq[String] = {
-    require(sc.schedulerBackend.isInstanceOf[CoarseCookSchedulerBackend],
-            "The current scheduler backend is not Cook.")
-    sc.schedulerBackend
-      .asInstanceOf[CoarseCookSchedulerBackend]
-      .getExecutorIds()
-  }
+  def getExecutorIds: Seq[String] =
+    schedulerBackend.getExecutorIds()
 
+  /**
+    * Return the current executor limit which may be [[Int.MaxValue]]
+    * before properly initialized. For Cook, it is properly set
+    * when creating `SparkContext`.
+    *
+    * @return the current executor limit.
+    */
+  def getExecutorLimit: Int =
+    schedulerBackend.executorLimit
 }
 
 object CookSchedulerContext {

--- a/core/src/main/scala/org/apache/spark/scheduler/CookSchedulerContext.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/CookSchedulerContext.scala
@@ -25,7 +25,7 @@ case class CookSchedulerContext(
 
   @transient val conf: SparkConf = sc.getConf
 
-  @transient val schedulerBackend: CoarseCookSchedulerBackend = {
+  @transient private[this] lazy val schedulerBackend: CoarseCookSchedulerBackend = {
     require(sc.schedulerBackend.isInstanceOf[CoarseCookSchedulerBackend],
       "The current scheduler backend is not Cook.")
     sc.schedulerBackend


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
Expose the current executor limit via CookSchedulerContext

## How was this patch tested?
Compile and run.
