### PR TITLE
Cook jobclient change to UUID and group generation.

### DIFF
--- a/resource-managers/cook/src/main/scala/org/apache/spark/scheduler/cluster/cook/CoarseCookSchedulerBackend.scala
+++ b/resource-managers/cook/src/main/scala/org/apache/spark/scheduler/cluster/cook/CoarseCookSchedulerBackend.scala
@@ -328,7 +328,7 @@ class CoarseCookSchedulerBackend(
         Seq("set", commandString) ++
         cleanup
 
-    var builder = new Job.Builder()
+    val builder = new Job.Builder()
       .setUUID(jobUUID)
       .setName(schedulerContext.cookJobNamePrefix)
       .setCommand(commandSeq.mkString("; "))
@@ -339,9 +339,7 @@ class CoarseCookSchedulerBackend(
       .disableMeaCulpaRetries()
       .setRetries(1)
 
-    if (group.isDefined) {
-      builder = builder.setGroup(group.get)
-    }
+    group.foreach(builder.setGroup(_))
 
     schedulerContext.executorCookContainerOption.foreach { container =>
       builder.setContainer(new JSONObject(container))

--- a/resource-managers/cook/src/main/scala/org/apache/spark/scheduler/cluster/cook/CoarseCookSchedulerBackend.scala
+++ b/resource-managers/cook/src/main/scala/org/apache/spark/scheduler/cluster/cook/CoarseCookSchedulerBackend.scala
@@ -470,7 +470,7 @@ class CoarseCookSchedulerBackend(
 
       if (requestedExecutors > 0) {
         val executorIdAndJob = (1 to requestedExecutors).map { _ =>
-          val jobUUID = UUID.randomUUID()
+          val jobUUID = JobClient.makeTemporalUUID()
           val executorId = mesosSchedulerBackend.newMesosTaskId()
           val job =
             createJob(schedulerContext.coresPerCookJob, jobUUID, executorId)


### PR DESCRIPTION
## What changes were proposed in this pull request?

* I changed the cook integration UUID generation to use some new code that makes temporally clustered UUID's.
* I changed the cook integration code to generate cook groups in the static cluster size case to help the scheduler. We're working on an optimization to get groups of jobs launched faster. 

## How was this patch tested?

* The new cook module appears to compile.
* (I'm having trouble compiling the entire spark distribution; spark-unsafe is causing problems)
